### PR TITLE
Fix TypeError when preferred_aliases provided as list of unicode

### DIFF
--- a/confusable_homoglyphs/confusables.py
+++ b/confusable_homoglyphs/confusables.py
@@ -89,7 +89,7 @@ def is_confusable(string, greedy=False, preferred_aliases=[]):
         otherwise.
     :rtype: bool or list
     """
-    preferred_aliases = list(map(str.upper, preferred_aliases))
+    preferred_aliases = [a.upper() for a in preferred_aliases]
     outputs = []
     checked = set()
     for char in string:

--- a/tests/test_confusables.py
+++ b/tests/test_confusables.py
@@ -49,6 +49,11 @@ class TestConfusables(unittest.TestCase):
         confusable = confusables.is_confusable(u'paρa', preferred_aliases=['greek'])[0]['character']
         self.assertEqual(confusable, 'p')
 
+        try:
+            confusables.is_confusable('', preferred_aliases=[u'latin'])
+        except TypeError:
+            self.fail('TypeError when preferred_aliases provided as unicode')
+
     def test_dangerous(self):
         self.assertTrue(confusables.is_dangerous(looks_good))
         self.assertTrue(confusables.is_dangerous(u' ρττ a'))
@@ -61,6 +66,7 @@ class TestConfusables(unittest.TestCase):
         self.assertFalse(confusables.is_dangerous(is_good))
         self.assertFalse(confusables.is_dangerous(u' ρτ.τ'))
         self.assertFalse(confusables.is_dangerous(u'ρτ.τ'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This fixes #1 in my environment. Test case included and successfully run on Python 2.7 and 3.5.

Line 79: Added an empty line to fix this warning:
expected 2 blank lines after class or function definition, found 1 [E305]
