### PR TITLE
Fix TypeError when allowed_aliases provided as list of unicode

### DIFF
--- a/confusable_homoglyphs/confusables.py
+++ b/confusable_homoglyphs/confusables.py
@@ -34,7 +34,7 @@ def is_mixed_script(string, allowed_aliases=['COMMON']):
     :return: Whether ``string`` is considered mixed-scripts or not.
     :rtype: bool
     """
-    allowed_aliases = map(str.upper, allowed_aliases)
+    allowed_aliases = [a.upper() for a in allowed_aliases]
     cats = unique_aliases(string) - set(allowed_aliases)
     return len(cats) > 1
 

--- a/tests/test_confusables.py
+++ b/tests/test_confusables.py
@@ -24,6 +24,11 @@ class TestConfusables(unittest.TestCase):
         self.assertFalse(confusables.is_mixed_script(u'ρτ.τ'))
         self.assertFalse(confusables.is_mixed_script(u'ρτ.τ '))
 
+        try:
+            confusables.is_mixed_script('', allowed_aliases=[u'COMMON'])
+        except TypeError:
+            self.fail('TypeError when allowed_aliases provided as unicode')
+
     def test_is_confusable(self):
         greek = confusables.is_confusable(looks_good, preferred_aliases=['latin'])
         self.assertEqual(greek[0]['character'], greek_a)


### PR DESCRIPTION
This fixes the same error as with preferred_aliases, caused by invocation of str.upper() on each element in the list of whatever is provided, which I replaced with a more general list comprehension. Should have been part of the last pull request, but it didn't occur to me. This time I made sure there are no other invocations of str's methods left to worry about, upper() or otherwise, so this pull request should be the last of the series.